### PR TITLE
Ensure correct container id is passed to Caerdon Wardrobe

### DIFF
--- a/external/CaedronWardrobeSupport.lua
+++ b/external/CaedronWardrobeSupport.lua
@@ -17,9 +17,9 @@ local function ItemSlotUpdated(self, bagSet, containerId, subContainerId, slotId
             showSellables=true
         }
 
-        CaerdonWardrobe:ProcessItem(itemId, bagId, slotId, button, options)
+        CaerdonWardrobe:ProcessItem(itemId, subContainerId, slotId, button, options)
     else
-		CaerdonWardrobe:ProcessItem(nil, bagId, slotId, button, nil)
+        CaerdonWardrobe:ProcessItem(nil, subContainerId, slotId, button, nil)
     end 
 end
 

--- a/external/CaedronWardrobeSupport.lua
+++ b/external/CaedronWardrobeSupport.lua
@@ -4,23 +4,84 @@ if IsAddOnLoaded("CaerdonWardrobe") then
     CaerdonWardrobe:RegisterBagAddon();
 end
 
+local function ProcessItem(bagId, slotId, button)
+    local bag = bagId
+
+    if slotId then
+        local slot = slotId
+ 
+        if bag == -1 then
+            bag = "BankFrame"
+            slot = BankButtonIDToInvSlotID(slot)
+        end
+
+        local itemId = GetContainerItemID(bagId, slotId)
+        if itemId then
+            local options = {
+                showMogIcon=true,
+                showBindStatus=true,
+                showSellables=true
+            }
+
+            CaerdonWardrobe:ProcessItem(itemId, bag, slot, button, options)
+        else
+            CaerdonWardrobe:ProcessItem(nil, bag, slot, button, nil)
+        end 
+    end
+end
+
 local function ItemSlotUpdated(self, bagSet, containerId, subContainerId, slotId, button)
     if not IsAddOnLoaded("CaerdonWardrobe") then
         return
     end
 
-    local itemId = GetContainerItemID(subContainerId, slotId)
-    if itemId then
-        local options = {
-            showMogIcon=true,
-            showBindStatus=true,
-            showSellables=true
-        }
-
-        CaerdonWardrobe:ProcessItem(itemId, subContainerId, slotId, button, options)
-    else
-        CaerdonWardrobe:ProcessItem(nil, subContainerId, slotId, button, nil)
-    end 
+    ProcessItem(subContainerId, slotId, button)
 end
 
+local function OnEvent(self, event, ...)
+    local handler = self[event]
+    if(handler) then
+        handler(self, ...)
+    end
+end
+
+local CaerdonWardrobeBaudBagFrame = CreateFrame("FRAME")
+CaerdonWardrobeBaudBagFrame:RegisterEvent "ADDON_LOADED"
+CaerdonWardrobeBaudBagFrame:SetScript("OnEvent", OnEvent)
+
 hooksecurefunc(BaudBag, "ItemSlot_Updated", ItemSlotUpdated)
+
+
+local function RefreshItems()
+    -- Something changed in the transmog collection.  Time to refresh.
+    -- Note: This is primarily necessary to support proper event handling
+    -- with multiple accounts logged in at the same time (i.e. learning an
+    -- appearance on the other account).
+    BaudUpdateJoinedBags()
+end
+
+function CaerdonWardrobeBaudBagFrame:ADDON_LOADED(name)
+    if IsLoggedIn() then
+        OnEvent(CaerdonWardrobeBaudBagFrame, "PLAYER_LOGIN")
+    else
+        CaerdonWardrobeBaudBagFrame:RegisterEvent "PLAYER_LOGIN"
+    end
+end
+
+function CaerdonWardrobeBaudBagFrame:PLAYER_LOGIN(...)
+    CaerdonWardrobeBaudBagFrame:RegisterEvent "TRANSMOG_COLLECTION_UPDATED"
+    CaerdonWardrobeBaudBagFrame:RegisterEvent "TRANSMOG_COLLECTION_SOURCE_ADDED"
+    CaerdonWardrobeBaudBagFrame:RegisterEvent "TRANSMOG_COLLECTION_SOURCE_REMOVED"
+end
+
+function CaerdonWardrobeBaudBagFrame:TRANSMOG_COLLECTION_UPDATED()
+    RefreshItems()
+end
+
+function CaerdonWardrobeBaudBagFrame:TRANSMOG_COLLECTION_SOURCE_ADDED()
+    RefreshItems()
+end
+
+function CaerdonWardrobeBaudBagFrame:TRANSMOG_COLLECTION_SOURCE_REMOVED()
+    RefreshItems()
+end

--- a/external/CaedronWardrobeSupport.lua
+++ b/external/CaedronWardrobeSupport.lua
@@ -10,11 +10,6 @@ local function ProcessItem(bagId, slotId, button)
     if slotId then
         local slot = slotId
  
-        if bag == -1 then
-            bag = "BankFrame"
-            slot = BankButtonIDToInvSlotID(slot)
-        end
-
         local itemId = GetContainerItemID(bagId, slotId)
         if itemId then
             local options = {


### PR DESCRIPTION
This ensures basic bag functionality works in conjunction with Caerdon Wardrobe.  It looks like some of the bank functionality may still need enhanced to show icons correctly for the main bank container, but this resolves the error popups caused by the player bags.